### PR TITLE
feat: support React 18 and React 19 as megane-viewer peers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,37 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_on_error: true
 
+  test-ts-react18:
+    name: TypeScript tests (React 18)
+    # megane-viewer declares peerDependencies react "^18.2.0 || ^19.0.0" while the
+    # repo develops against React 19. This job swaps in React 18 (runtime + types)
+    # and re-runs the type check and unit tests so the lower bound of the peer
+    # range stays honest. No Codecov upload — the coverage gate is the React 19 job.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: |
+          # Retry transient network failures from rustwasm.github.io (~once a week on GH-hosted runners).
+          for i in 1 2 3; do
+            curl -fsSL https://rustwasm.github.io/wasm-pack/installer/init.sh | sh && break
+            echo "wasm-pack install attempt $i failed; retrying in $((i*5))s"
+            sleep $((i*5))
+          done
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build:wasm
+      - name: Swap in React 18
+        run: npm i --no-save react@18 react-dom@18 @types/react@18 @types/react-dom@18
+      - run: npx tsc --noEmit
+      - run: npx vitest run
+
   render-smoke:
     name: Bundle render smoke test
     # Builds the Vite bundles with the EXACT locked toolchain (npm ci) and loads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`megane-viewer` now supports React 18 and React 19.** `react` / `react-dom` moved from `dependencies` to `peerDependencies` (`^18.2.0 || ^19.0.0`) — the npm library bundle has always externalized React and used the host app's copy, but the old `dependencies` entry forced React 19 into consumers' trees and risked a duplicate React. Development and the self-contained bundles (webapp, anywidget, VSCode webview) stay on React 19; the JupyterLab labextension already ran on the host's React 18. CI gains a `test-ts-react18` job that type-checks and runs the unit suite against React 18 to keep the lower bound honest.
+
+### Fixed
+
+- Testing Library auto-cleanup never ran in the vitest suite (vitest runs with `globals` disabled, which silently disables it), so components stayed mounted across tests in a file. Their re-run effects could re-register stale module-level handlers over the next test's registrations — masked by scheduling luck on React 19, but failing deterministically on React 18. `tests/ts/setup.ts` now calls `cleanup()` in an explicit `afterEach`.
+
 ## [0.11.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ pip install megane
 npm install megane-viewer
 ```
 
+Works with React 18 and React 19 (peer dependency: `react@^18.2.0 || ^19.0.0`).
+
 ## Quick Start
 
 ### Jupyter widget

--- a/docs/docs/guide/web.md
+++ b/docs/docs/guide/web.md
@@ -12,6 +12,8 @@ megane can be embedded in React applications as a component library, published t
 npm install megane-viewer
 ```
 
+`megane-viewer` works with both React 18 and React 19 — it declares a peer dependency of `react@^18.2.0 || ^19.0.0` (and the matching `react-dom`) and uses your app's React instance rather than bundling its own.
+
 ## Full-Featured Viewer
 
 The easiest way to get started is the `MeganeViewer` component. It includes the 3D viewport, sidebar, appearance panel, timeline, tooltip, and measurement panel — everything you need in a single component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "@xyflow/react": "^12.0.0",
         "driver.js": "^1.4.0",
         "gif.js": "^0.2.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
         "three": "^0.183.0",
         "zustand": "^5.0.0"
       },
@@ -36,11 +34,17 @@
         "playwright": "1.56",
         "pngjs": "^7.0.0",
         "prettier": "^3.8.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.57.0",
         "vite": "^6.0.0",
         "vite-plugin-wasm": "^3.5.0",
         "vitest": "^4.1.8"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -93,10 +93,12 @@
     "@xyflow/react": "^12.0.0",
     "driver.js": "^1.4.0",
     "gif.js": "^0.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
     "three": "^0.183.0",
     "zustand": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -105,6 +107,8 @@
     "@types/dagre": "^0.7.54",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "@types/three": "^0.183.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.8",

--- a/tests/ts/setup.ts
+++ b/tests/ts/setup.ts
@@ -1,1 +1,12 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Testing Library's auto-cleanup relies on a global `afterEach`, which is not
+// available because vitest runs with `globals` disabled. Without this hook,
+// components stay mounted across tests within a file and their re-run effects
+// can clobber module-level state registered by the next test's component
+// (observed as stale-closure handler registrations under React 18).
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary

Makes the `megane-viewer` npm package work with both React 18 and React 19.

The library bundle (`vite.lib.config.ts`) has always externalized `react`/`react-dom` and used the host app's React, but `package.json` listed `react: ^19.0.0` under `dependencies` with no `peerDependencies` — so installing `megane-viewer` into a React 18 app pulled React 19 into the tree and risked a duplicate React. The runtime code uses no React-19-only APIs (the JupyterLab labextension already builds the same `src/` tree against the host's React 18), so this is a dependency-contract fix plus a test-infrastructure fix:

- **`package.json`**: move `react`/`react-dom` to `peerDependencies: "^18.2.0 || ^19.0.0"`; keep React 19 in `devDependencies` for local dev, builds, and tests. Lockfile resolution is unchanged (19.2.4).
- **CI**: new `test-ts-react18` job swaps in `react@18` + `@types/react@18` and re-runs `tsc --noEmit` + the vitest suite, keeping the lower bound of the peer range verified. No Codecov upload from this job (the coverage gate stays on the React 19 job).
- **Test fix**: Testing Library auto-cleanup never ran (vitest runs with `globals` disabled, which silently disables RTL's built-in `afterEach` cleanup), so components stayed mounted across tests within a file and their re-run effects re-registered stale module-level load handlers over the next test's registrations. React 19 masked this by scheduling luck; React 18 failed 3 `useNodeLoadHandlers` tests deterministically. `tests/ts/setup.ts` now calls `cleanup()` in an explicit `afterEach`.
- **Docs**: README, `docs/docs/guide/web.md`, and CHANGELOG note the supported peer range.

The self-contained bundles (webapp, anywidget widget, VSCode webview) ship their own React and are unaffected; the JupyterLab labextension already runs on the host's React 18.

## Test Plan

- [x] `npm test` passes — 2042 passed / 1 skipped under React 19 (with `--coverage`), and the full suite also run against `react@18.3.1` + `@types/react@18` (`npx tsc --noEmit` + `npx vitest run`): 2042 passed / 1 skipped
- [x] `cargo test -p megane-core` passes — no Rust changes (dependency/CI/test-setup/docs only)
- [ ] `python -m pytest` passes (no Python changes included)
- [x] Manually verified the change in the browser — Playwright `webapp` project: 5/5 passed, zero baseline diffs (no `src/` changes; run as a side-effect sweep for the dependency reclassification and the shared test-setup change). No baselines updated.
- [x] `npm pack --dry-run` shows `peerDependencies` and `dist/lib.js` still imports `react`/`react-dom` as externals (no bundled React)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Et9y2VGCzNjwo8tTnCxL2)_