### PR TITLE
fix: React 18 compatibility, stylesheet exports, and TypeScript declarations for the npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **The `megane-viewer` npm package now ships TypeScript declarations.** `npm run build:lib` emits `dist/types/` (`tsc -p tsconfig.build-types.json` + a post-processing pass that strips stylesheet side-effect imports and adds explicit `.js` extensions so `moduleResolution: node16/nodenext` consumers resolve them), and the `.` / `./lib` exports carry `types` conditions. Consumers no longer hit `TS7016: Could not find a declaration file` or need hand-written ambient declarations. `@types/three` moved from `devDependencies` to `dependencies` because the public declarations reference three's types.
+- **The bundled stylesheet is importable via the `exports` map.** `import "megane-viewer/styles.css"` (alias) and `import "megane-viewer/dist/megane-viewer.css"` (real path) both resolve; previously any stylesheet import failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Deep imports of `./dist/widget.js` / `./dist/lib.js` and `./package.json` are exported as well.
+
 ## [0.12.0] - 2026-08-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - **The `megane-viewer` npm package now ships TypeScript declarations.** `npm run build:lib` emits `dist/types/` (`tsc -p tsconfig.build-types.json` + a post-processing pass that strips stylesheet side-effect imports and adds explicit `.js` extensions so `moduleResolution: node16/nodenext` consumers resolve them), and the `.` / `./lib` exports carry `types` conditions. Consumers no longer hit `TS7016: Could not find a declaration file` or need hand-written ambient declarations. `@types/three` moved from `devDependencies` to `dependencies` because the public declarations reference three's types.
 - **The bundled stylesheet is importable via the `exports` map.** `import "megane-viewer/styles.css"` (alias) and `import "megane-viewer/dist/megane-viewer.css"` (real path) both resolve; previously any stylesheet import failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Deep imports of `./dist/widget.js` / `./dist/lib.js` and `./package.json` are exported as well.
 
+### Fixed
+
+- **The npm library bundle crashed React 18 hosts with `Objects are not valid as a React child`.** `vite.lib.config.ts` externalized only the exact specifiers `react` / `react-dom` / `three`, so subpath imports — most importantly `react/jsx-runtime`, which the automatic JSX transform emits — were bundled into `dist/lib.js`, baking in React 19's element symbol (`react.transitional.element`) that React 18's reconciler does not recognize. The externals are now prefix regexes (`/^react($|\/)/` etc.), so `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-dom/client`, and `three/examples/jsm/*` all resolve from the host application (~147 kB smaller bundle). The anywidget `widget.js` bundle intentionally stays fully self-contained. Verified by rendering `MeganeViewer` from the packed tarball on both React 18 (previously crashed, now renders) and React 19 hosts.
+
 ## [0.12.0] - 2026-08-10
 
 ### Changed
@@ -139,7 +143,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 #### Representations / rendering
 
-- **Cartoon/ribbon representation** for proteins, rewritten for Mol*-quality output (#362, #400, #411)
+- **Cartoon/ribbon representation** for proteins, rewritten for Mol\*-quality output (#362, #400, #411)
 - **Solvent-Accessible Surface (SAS) representation** (#406)
 - **OVITO-style surface mesh** pipeline node (alpha-shape envelope) and template (#412, #432)
 - **Isosurface representation** for volumetric data (#364, #443)
@@ -238,6 +242,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [0.6.2] - 2026-03-25
 
 No user-facing changes in this version.
+
 ## [0.6.1] - 2026-03-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ docker run --rm -p 8080:8080 -v ./mydata:/data megane \
 
 ```tsx
 import { useCallback } from "react";
+import "megane-viewer/styles.css";
 import { MeganeViewer, usePipelineStore } from "megane-viewer/lib";
 
 function App() {

--- a/docs/docs/guide/web.md
+++ b/docs/docs/guide/web.md
@@ -14,12 +14,21 @@ npm install megane-viewer
 
 `megane-viewer` works with both React 18 and React 19 — it declares a peer dependency of `react@^18.2.0 || ^19.0.0` (and the matching `react-dom`) and uses your app's React instance rather than bundling its own.
 
+The package ships TypeScript declarations for both entry points (`megane-viewer` and `megane-viewer/lib`), so no manual ambient declarations are needed.
+
+Import the bundled stylesheet once (e.g. in your app entry) so the viewer UI is styled:
+
+```ts
+import "megane-viewer/styles.css";
+```
+
 ## Full-Featured Viewer
 
 The easiest way to get started is the `MeganeViewer` component. It includes the 3D viewport, sidebar, appearance panel, timeline, tooltip, and measurement panel — everything you need in a single component.
 
 ```tsx
 import { useCallback } from "react";
+import "megane-viewer/styles.css";
 import { MeganeViewer } from "megane-viewer/lib";
 import { usePipelineStore } from "megane-viewer/lib";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
+        "@types/three": "^0.183.0",
         "@xyflow/react": "^12.0.0",
         "driver.js": "^1.4.0",
         "gif.js": "^0.2.0",
@@ -23,7 +24,6 @@
         "@types/dagre": "^0.7.54",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@types/three": "^0.183.0",
         "@vitejs/plugin-react": "^4.3.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^9.39.4",
@@ -511,7 +511,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1708,7 +1707,6 @@
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/aria-query": {
@@ -1876,14 +1874,12 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
       "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/three": {
       "version": "0.183.1",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.183.1.tgz",
       "integrity": "sha512-f2Pu5Hrepfgavttdye3PsH5RWyY/AvdZQwIVhrc4uNtvF7nOWJacQKcoVJn0S4f0yYbmAE6AR+ve7xDcuYtMGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
@@ -1899,7 +1895,6 @@
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2327,7 +2322,6 @@
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
       "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xyflow/react": {
@@ -3397,7 +3391,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -4074,7 +4067,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.0.1.tgz",
       "integrity": "sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -21,13 +21,27 @@
   ],
   "main": "./dist/widget.js",
   "module": "./dist/widget.js",
+  "types": "./dist/types/widget.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/widget.d.ts",
       "import": "./dist/widget.js"
     },
     "./lib": {
+      "types": "./dist/types/lib.d.ts",
       "import": "./dist/lib.js"
-    }
+    },
+    "./styles.css": "./dist/megane-viewer.css",
+    "./dist/megane-viewer.css": "./dist/megane-viewer.css",
+    "./dist/lib.js": {
+      "types": "./dist/types/lib.d.ts",
+      "import": "./dist/lib.js"
+    },
+    "./dist/widget.js": {
+      "types": "./dist/types/widget.d.ts",
+      "import": "./dist/widget.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist/",
@@ -37,10 +51,11 @@
   "scripts": {
     "dev": "vite",
     "build:wasm": "node scripts/build-wasm.mjs",
-    "build": "npm run build:wasm && tsc && vite build && vite build --config vite.widget.config.ts && rm -rf dist && vite build --config vite.widget.config.ts --outDir dist && vite build --config vite.lib.config.ts && npm run build:lab",
+    "build": "npm run build:wasm && tsc && vite build && vite build --config vite.widget.config.ts && rm -rf dist && vite build --config vite.widget.config.ts --outDir dist && vite build --config vite.lib.config.ts && npm run build:types && npm run build:lab",
     "build:app": "npm run build:wasm && tsc && vite build",
     "build:widget": "vite build --config vite.widget.config.ts",
-    "build:lib": "npm run build:wasm && vite build --config vite.widget.config.ts --outDir dist && vite build --config vite.lib.config.ts",
+    "build:lib": "npm run build:wasm && vite build --config vite.widget.config.ts --outDir dist && vite build --config vite.lib.config.ts && npm run build:types",
+    "build:types": "tsc -p tsconfig.build-types.json && node scripts/postprocess-dts.mjs",
     "build:lab": "cd jupyterlab-megane && npm install && npm run build",
     "preview": "vite preview",
     "demo:video": "node scripts/demo-video.mjs",
@@ -90,6 +105,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
+    "@types/three": "^0.183.0",
     "@xyflow/react": "^12.0.0",
     "driver.js": "^1.4.0",
     "gif.js": "^0.2.0",
@@ -109,7 +125,6 @@
     "@types/react-dom": "^19.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@types/three": "^0.183.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.39.4",

--- a/scripts/postprocess-dts.mjs
+++ b/scripts/postprocess-dts.mjs
@@ -1,0 +1,114 @@
+/**
+ * Post-processes the emitted type declarations (dist/types/) after
+ * `tsc -p tsconfig.build-types.json`, fixing two things tsc cannot:
+ *
+ * 1. TypeScript preserves side-effect imports (`import "./tour.css";`) in
+ *    .d.ts output, but stylesheets are never shipped inside dist/types/, so
+ *    those specifiers cannot resolve in consumer projects and break
+ *    type-checking for consumers that don't set skipLibCheck. Declarations
+ *    never need styles, so every side-effect .css import is stripped.
+ *
+ * 2. The sources use extensionless relative imports (bundler resolution),
+ *    which tsc copies verbatim into the .d.ts. Consumers on
+ *    `moduleResolution: node16/nodenext` then fail with TS2834 ("Relative
+ *    import paths need explicit file extensions"). Since megane-viewer is
+ *    `"type": "module"`, every relative specifier in the declarations gets an
+ *    explicit `.js` extension (which TypeScript maps back to the sibling
+ *    `.d.ts`), including inline `import("./x")` type references.
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TYPES_DIR = join(__dirname, "..", "dist", "types");
+
+/**
+ * Remove side-effect stylesheet imports (`import "x.css";`) from declaration
+ * source text. Imports with bindings (`import styles from "x.css"`) are left
+ * untouched — they carry a type and would need a different fix.
+ * @param {string} source
+ * @returns {string}
+ */
+export function stripStyleImports(source) {
+  return source.replace(/^import\s+["'][^"']+\.css["'];\r?\n?/gm, "");
+}
+
+/**
+ * Append explicit `.js` extensions to extensionless relative specifiers in
+ * declaration source text so node16/nodenext consumers can resolve them.
+ * Handles `import ... from "./x"`, `export ... from "./x"` and inline
+ * `import("./x")` type references.
+ * @param {string} source
+ * @param {(specifier: string) => "file" | "directory" | null} classify
+ *   Callback reporting whether the specifier resolves (relative to the file
+ *   being processed) to a declaration file (`spec.d.ts`) or a directory with
+ *   an index declaration (`spec/index.d.ts`). Unresolvable specifiers are
+ *   left untouched.
+ * @returns {string}
+ */
+export function addExplicitExtensions(source, classify) {
+  const rewrite = (specifier) => {
+    if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
+      return specifier;
+    }
+    if (/\.(js|mjs|cjs|json|css)$/.test(specifier)) {
+      return specifier;
+    }
+    const kind = classify(specifier);
+    if (kind === "file") return `${specifier}.js`;
+    if (kind === "directory") return `${specifier}/index.js`;
+    return specifier;
+  };
+  return source
+    .replace(
+      /(from\s*)(["'])([^"']+)\2/g,
+      (_m, prefix, quote, spec) => `${prefix}${quote}${rewrite(spec)}${quote}`,
+    )
+    .replace(
+      /(import\s*\(\s*)(["'])([^"']+)\2(\s*\))/g,
+      (_m, prefix, quote, spec, suffix) => `${prefix}${quote}${rewrite(spec)}${quote}${suffix}`,
+    );
+}
+
+/**
+ * Recursively collect .d.ts files under a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+export function collectDtsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectDtsFiles(full));
+    } else if (entry.name.endsWith(".d.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function main() {
+  let changed = 0;
+  for (const file of collectDtsFiles(TYPES_DIR)) {
+    const source = readFileSync(file, "utf-8");
+    const fileDir = dirname(file);
+    const cleaned = addExplicitExtensions(stripStyleImports(source), (specifier) => {
+      if (existsSync(join(fileDir, `${specifier}.d.ts`))) return "file";
+      if (existsSync(join(fileDir, specifier, "index.d.ts"))) return "directory";
+      return null;
+    });
+    if (cleaned !== source) {
+      writeFileSync(file, cleaned);
+      changed += 1;
+    }
+  }
+  console.log(`[postprocess-dts] rewrote ${changed} file(s)`);
+}
+
+// Only run when executed directly, so the pure helpers can be imported in tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/tests/ts/package-exports.test.ts
+++ b/tests/ts/package-exports.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Guards the npm package surface of megane-viewer.
+ *
+ * Consumers import the JS entries ("megane-viewer", "megane-viewer/lib"),
+ * the stylesheet ("megane-viewer/styles.css") and TypeScript declarations.
+ * A missing `exports` entry fails at install time in user projects with
+ * ERR_PACKAGE_PATH_NOT_EXPORTED, and a missing `types` condition surfaces
+ * as TS7016 — neither is caught by any other test, so pin the map here.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(__dirname, "../..");
+
+const pkg = JSON.parse(readFileSync(path.join(root, "package.json"), "utf-8")) as {
+  types?: string;
+  files?: string[];
+  scripts: Record<string, string>;
+  exports: Record<string, string | Record<string, string>>;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+};
+
+const typesConfig = JSON.parse(
+  readFileSync(path.join(root, "tsconfig.build-types.json"), "utf-8"),
+) as {
+  compilerOptions: Record<string, unknown>;
+  include: string[];
+};
+
+describe("package.json exports map", () => {
+  it("exposes the JS entry points with types + import conditions", () => {
+    for (const subpath of [".", "./lib", "./dist/widget.js", "./dist/lib.js"]) {
+      const entry = pkg.exports[subpath];
+      expect(entry, `exports["${subpath}"]`).toBeTypeOf("object");
+      const conditions = entry as Record<string, string>;
+      expect(conditions.types, `types condition for "${subpath}"`).toMatch(
+        /^\.\/dist\/types\/.+\.d\.ts$/,
+      );
+      expect(conditions.import, `import condition for "${subpath}"`).toMatch(/^\.\/dist\/.+\.js$/);
+      // Node picks the first matching condition, so "types" must come first.
+      expect(Object.keys(conditions)[0]).toBe("types");
+    }
+  });
+
+  it("keeps deep imports and friendly aliases pointing at the same files", () => {
+    expect(pkg.exports["./dist/widget.js"]).toEqual(pkg.exports["."]);
+    expect(pkg.exports["./dist/lib.js"]).toEqual(pkg.exports["./lib"]);
+  });
+
+  it("exposes the stylesheet under both the alias and the real dist path", () => {
+    expect(pkg.exports["./styles.css"]).toBe("./dist/megane-viewer.css");
+    expect(pkg.exports["./dist/megane-viewer.css"]).toBe("./dist/megane-viewer.css");
+  });
+
+  it("exposes package.json for tooling", () => {
+    expect(pkg.exports["./package.json"]).toBe("./package.json");
+  });
+
+  it("only references files shipped in the npm tarball", () => {
+    const files = pkg.files ?? [];
+    expect(files).toContain("dist/");
+    const targets = Object.values(pkg.exports).flatMap((entry) =>
+      typeof entry === "string" ? [entry] : Object.values(entry),
+    );
+    for (const target of targets) {
+      expect(
+        target === "./package.json" || target.startsWith("./dist/"),
+        `"${target}" must live under dist/ (or be package.json)`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps the top-level types field in sync with the root export", () => {
+    const rootEntry = pkg.exports["."] as Record<string, string>;
+    expect(pkg.types).toBe(rootEntry.types);
+  });
+
+  it("ships @types/three as a runtime dependency", () => {
+    // The public d.ts reference three's types (Snapshot, MoleculeRenderer,
+    // …), so consumers with skipLibCheck:false hit TS7016 unless @types/three
+    // is installed alongside the package — it must not be dev-only.
+    expect(pkg.dependencies["@types/three"]).toBeDefined();
+    expect(pkg.devDependencies["@types/three"]).toBeUndefined();
+  });
+});
+
+describe("type declaration build", () => {
+  it("is wired into the lib and full builds", () => {
+    expect(pkg.scripts["build:types"]).toContain("tsc -p tsconfig.build-types.json");
+    // Emitted d.ts keep side-effect CSS imports (unresolvable inside
+    // dist/types/) and extensionless relative specifiers (TS2834 under
+    // node16/nodenext) — the post-processing must run after tsc.
+    expect(pkg.scripts["build:types"]).toContain("node scripts/postprocess-dts.mjs");
+    expect(pkg.scripts["build:lib"]).toContain("npm run build:types");
+    expect(pkg.scripts["build"]).toContain("npm run build:types");
+    // `build` wipes dist/ midway; declarations must be emitted afterwards.
+    const build = pkg.scripts["build"];
+    expect(build.indexOf("npm run build:types")).toBeGreaterThan(build.indexOf("rm -rf dist"));
+  });
+
+  it("emits declarations only, into dist/types, for both entry points", () => {
+    const opts = typesConfig.compilerOptions;
+    expect(opts.emitDeclarationOnly).toBe(true);
+    expect(opts.declaration).toBe(true);
+    expect(opts.outDir).toBe("dist/types");
+    expect(opts.rootDir).toBe("src");
+    expect(typesConfig.include).toContain("src/lib.ts");
+    expect(typesConfig.include).toContain("src/widget.ts");
+  });
+});

--- a/tests/ts/postprocess-dts.test.ts
+++ b/tests/ts/postprocess-dts.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
+
+// The declaration post-processor is a build-tooling script
+// (scripts/postprocess-dts.mjs), so it lives outside the instrumented
+// coverage scope (src/ trees only). These tests exercise its pure helpers.
+import {
+  stripStyleImports,
+  addExplicitExtensions,
+  collectDtsFiles,
+} from "../../scripts/postprocess-dts.mjs";
+
+describe("stripStyleImports", () => {
+  it("removes side-effect css imports with double quotes", () => {
+    const source = 'import "./tour.css";\nexport declare class MeganeTour {\n}\n';
+    expect(stripStyleImports(source)).toBe("export declare class MeganeTour {\n}\n");
+  });
+
+  it("removes side-effect css imports with single quotes", () => {
+    expect(stripStyleImports("import './style.css';\nexport {};\n")).toBe("export {};\n");
+  });
+
+  it("removes package css imports too", () => {
+    const source =
+      'import "@xyflow/react/dist/style.css";\nimport "driver.js/dist/driver.css";\nexport declare const x: number;\n';
+    expect(stripStyleImports(source)).toBe("export declare const x: number;\n");
+  });
+
+  it("keeps non-css imports and bound imports untouched", () => {
+    const source =
+      'import "./setup";\nimport styles from "./inline.css";\nimport { a } from "./a";\n';
+    expect(stripStyleImports(source)).toBe(source);
+  });
+
+  it("only strips whole-line imports, not css mentioned mid-line", () => {
+    const source = 'export declare const cssPath = "./tour.css";\n';
+    expect(stripStyleImports(source)).toBe(source);
+  });
+});
+
+describe("addExplicitExtensions", () => {
+  const asFile = () => "file" as const;
+
+  it("appends .js to relative import and export specifiers", () => {
+    const source =
+      'import { A } from "./a";\nexport { B } from "../b";\nexport type { C } from "./sub/c";\n';
+    expect(addExplicitExtensions(source, asFile)).toBe(
+      'import { A } from "./a.js";\nexport { B } from "../b.js";\nexport type { C } from "./sub/c.js";\n',
+    );
+  });
+
+  it("rewrites inline import() type references", () => {
+    const source =
+      'export declare const state: import("./renderer/MoleculeRenderer").MeganeCameraState;\n';
+    expect(addExplicitExtensions(source, asFile)).toBe(
+      'export declare const state: import("./renderer/MoleculeRenderer.js").MeganeCameraState;\n',
+    );
+  });
+
+  it("maps directory specifiers to index.js", () => {
+    const source = 'import { P } from "./pipeline";\n';
+    expect(addExplicitExtensions(source, () => "directory")).toBe(
+      'import { P } from "./pipeline/index.js";\n',
+    );
+  });
+
+  it("leaves bare (package) specifiers untouched", () => {
+    const source = 'import * as THREE from "three";\nimport { create } from "zustand";\n';
+    expect(addExplicitExtensions(source, asFile)).toBe(source);
+  });
+
+  it("leaves already-extensioned and unresolvable specifiers untouched", () => {
+    const source = 'import { A } from "./a.js";\nimport { B } from "./gone";\n';
+    expect(addExplicitExtensions(source, (spec) => (spec === "./gone" ? null : "file"))).toBe(
+      source,
+    );
+  });
+});
+
+describe("collectDtsFiles", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("recursively finds only .d.ts files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "megane-dts-"));
+    dirs.push(dir);
+    mkdirSync(join(dir, "nested"));
+    writeFileSync(join(dir, "lib.d.ts"), "");
+    writeFileSync(join(dir, "nested", "widget.d.ts"), "");
+    writeFileSync(join(dir, "nested", "notes.txt"), "");
+    writeFileSync(join(dir, "styles.css"), "");
+
+    const found = collectDtsFiles(dir).sort();
+    expect(found).toEqual([join(dir, "lib.d.ts"), join(dir, "nested", "widget.d.ts")]);
+  });
+});

--- a/tests/ts/vite-lib-config.test.ts
+++ b/tests/ts/vite-lib-config.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment node
+/**
+ * Guards the npm library bundle's external boundary (vite.lib.config.ts).
+ *
+ * The externals must match *subpaths*, not just exact package names: with
+ * exact strings, `react/jsx-runtime` (emitted by the automatic JSX transform)
+ * was bundled, baking the building React's element symbol
+ * (`react.transitional.element` on React 19) into `dist/lib.js` — React 18
+ * hosts then crashed with "Objects are not valid as a React child".
+ *
+ * The anywidget bundle (vite.widget.config.ts) is the opposite: it must stay
+ * fully self-contained (no externals), because anywidget loads it as a single
+ * ESM file with no bare-import resolution.
+ */
+import { describe, expect, it } from "vitest";
+import libConfig from "../../vite.lib.config";
+import widgetConfig from "../../vite.widget.config";
+
+function getExternal(config: typeof libConfig): (string | RegExp)[] {
+  const external = config.build?.rollupOptions?.external;
+  expect(Array.isArray(external)).toBe(true);
+  return external as (string | RegExp)[];
+}
+
+function isExternal(patterns: (string | RegExp)[], id: string): boolean {
+  return patterns.some((p) => (typeof p === "string" ? p === id : p.test(id)));
+}
+
+describe("vite.lib.config externals", () => {
+  const external = getExternal(libConfig);
+
+  it.each([
+    "react",
+    "react/jsx-runtime",
+    "react/jsx-dev-runtime",
+    "react-dom",
+    "react-dom/client",
+    "three",
+    "three/examples/jsm/controls/OrbitControls.js",
+    "three/examples/jsm/lines/LineMaterial.js",
+  ])("externalizes %s", (id) => {
+    expect(isExternal(external, id)).toBe(true);
+  });
+
+  it.each([
+    // Similarly-prefixed packages must stay bundled/resolved normally.
+    "react-router",
+    "three-stdlib",
+    "@xyflow/react",
+    "zustand",
+    "gif.js",
+  ])("does not externalize %s", (id) => {
+    expect(isExternal(external, id)).toBe(false);
+  });
+});
+
+describe("vite.widget.config self-containment", () => {
+  it("declares no externals — the anywidget bundle must be self-contained", () => {
+    expect(widgetConfig.build?.rollupOptions?.external).toBeUndefined();
+  });
+});

--- a/tsconfig.build-types.json
+++ b/tsconfig.build-types.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationMap": false,
+    "stripInternal": true,
+    "rootDir": "src",
+    "outDir": "dist/types"
+  },
+  "include": ["src/lib.ts", "src/widget.ts", "src/vite-env.d.ts", "src/types/gif.js.d.ts"],
+  "references": []
+}

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -28,7 +28,12 @@ export default defineConfig({
       fileName: () => "lib.js",
     },
     rollupOptions: {
-      external: ["react", "react-dom", "three"],
+      // Match subpaths too (react/jsx-runtime, react-dom/client,
+      // three/examples/jsm/*): exact-string externals leaked
+      // react/jsx-runtime into the bundle, baking in the building React's
+      // element symbol (react.transitional.element on React 19) and crashing
+      // React 18 hosts with "Objects are not valid as a React child".
+      external: [/^react($|\/)/, /^react-dom($|\/)/, /^three($|\/)/],
     },
     minify: true,
     sourcemap: false,


### PR DESCRIPTION
## Summary

Fixes three npm-consumer issues in the published `megane-viewer` package:

**1. The library bundle crashed React 18 hosts (`Objects are not valid as a React child`).** `vite.lib.config.ts` externalized only the exact specifiers `react` / `react-dom` / `three`, so subpath imports were bundled into `dist/lib.js` — most importantly `react/jsx-runtime`, which the automatic JSX transform emits for every component. That baked React 19's element symbol (`react.transitional.element`) into the bundle, which React 18's reconciler rejects. The externals are now prefix regexes (`/^react($|\/)/`, `/^react-dom($|\/)/`, `/^three($|\/)/`), so `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-dom/client`, and `three/examples/jsm/*` all resolve from the host application (lib chunk shrinks ~147 kB, 1121 kB → 974 kB). The anywidget `widget.js` bundle intentionally stays fully self-contained — it is loaded as a single ESM file with no bare-import resolution. A unit test pins the external patterns of both configs.

(The related nested-React issue — `react` in `dependencies` forcing a duplicate React 19 into consumer trees — was already fixed in 0.12.0, which moved `react`/`react-dom` to `peerDependencies "^18.2.0 || ^19.0.0"`.)

**2. Stylesheet (and deep imports) were blocked by the `exports` map.** `dist/megane-viewer.css` ships in the tarball, but any import of it failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` (deep imports of `dist/lib.js` / `dist/widget.js` too). The exports map now exposes:
- `megane-viewer/styles.css` (friendly alias) and `megane-viewer/dist/megane-viewer.css` (the real path)
- `megane-viewer/dist/widget.js` / `megane-viewer/dist/lib.js` deep imports (same conditions as `.` / `./lib`)
- `megane-viewer/package.json` for tooling

**3. No `.d.ts` were distributed**, so TypeScript projects hit `TS7016: Could not find a declaration file` and had to hand-write ambient declarations. Now:
- A new `build:types` script (wired into `build` and `build:lib`, so `publish-npm.yml` picks it up automatically) emits `dist/types/` via `tsc -p tsconfig.build-types.json` covering both entry points (`src/widget.ts`, `src/lib.ts`).
- `scripts/postprocess-dts.mjs` then fixes two things tsc leaves behind: side-effect CSS imports (`import "./tour.css"` — unresolvable inside `dist/types/`, breaks `skipLibCheck: false` consumers) are stripped, and extensionless relative specifiers get explicit `.js` extensions so `moduleResolution: node16/nodenext` consumers don't hit TS2834.
- `.` and `./lib` exports gain `types` conditions (ordered first, as Node/TS require) plus a top-level `types` field.
- `@types/three` moved from `devDependencies` to `dependencies`: the public declarations reference three's types (`Snapshot`, `MoleculeRenderer`, …), so it must install transitively.

Docs: README and `docs/docs/guide/web.md` now show `import "megane-viewer/styles.css"` in the React quick start; CHANGELOG updated.

**Verification with packed tarballs** (`npm pack` + fresh consumer projects):
- React 18 A/B: rendering `MeganeViewer` via `react-dom/server` with the **published 0.12.0** on React 18 reproduces the exact crash (`Objects are not valid as a React child`); the fixed tarball renders successfully on **both React 18 and React 19**.
- The rebuilt `dist/lib-*.js` contains zero occurrences of `react.transitional.element` and imports `react/jsx-runtime` / `three/examples/jsm/*` as externals.
- All 7 export subpaths resolve under Node ESM (`import.meta.resolve`) — previously 5 of them threw `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- A consumer `.tsx` importing `MeganeViewer`, `parseStructureText`, `Pipeline`, types, and the widget default export type-checks with `skipLibCheck: false` under **both** `moduleResolution: bundler` and `nodenext`.

New unit tests pin the exports map shape, the `build:types` wiring, the `@types/three` placement, the post-processor's pure helpers, and the vite external patterns (`tests/ts/vite-lib-config.test.ts` asserts subpaths like `react/jsx-runtime` and `three/examples/jsm/*` are external while `react-router`/`three-stdlib`-style prefixes are not, and that the widget config stays external-free).

Coverage note: the diff is config (`package.json`, `tsconfig.build-types.json`, `vite.lib.config.ts`), docs, tests, and a build-tooling script (`scripts/*.mjs`, outside the instrumented `src/` coverage scope, same as the existing `scripts/build-wasm.mjs`) — no instrumented source lines are added.

E2E note (rule #9): `vite.lib.config.ts` is on the UI-affecting list, so the `webapp` Playwright project was run as a side-effect sweep — 5/5 passed, no baseline changes. No Playwright host project consumes the npm lib bundle itself (hosts build via `vite.config.ts` / `vite.widget.config.ts` / the webview config, all untouched); the lib bundle was instead verified directly via the React 18/19 packed-tarball render checks above.

## Test Plan

- [x] `npm test` passes (167 files / 2076 tests, plus `npm test -- --coverage` for the Codecov-form lcov)
- [ ] `cargo test -p megane-core` passes (no Rust changes)
- [ ] `python -m pytest` passes (no Python changes)
- [x] Playwright `webapp` project: 5/5 passed (side-effect sweep for the vite config change; no baselines moved)
- [x] Manually verified via packed-tarball consumers: React 18 & 19 render checks, Node ESM resolution of all export subpaths, `tsc` (bundler and nodenext, `skipLibCheck: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RcKqssFcZH9WUoxcLrbHL