### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-08-12
+
 ### Fixed
 
 - **Four real-world file layouts from Jmol's demo corpus (`jsmol/data`) failed to load and now parse on every host.** Tested all 67 non-image files of that corpus against megane's parsers and fixed everything fixable:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "megane-core"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "quick-xml",
  "serde_json",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "megane-python"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "megane-core",
  "numpy",
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "megane-wasm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "js-sys",
  "megane-core",

--- a/crates/megane-core/Cargo.toml
+++ b/crates/megane-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-core"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "Core molecular structure parsers (PDB, GRO, XYZ, MOL, CIF, LAMMPS, XTC, .traj)"
 authors = ["hodakamori"]

--- a/crates/megane-python/Cargo.toml
+++ b/crates/megane-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-python"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "PyO3 Python bindings for megane molecular parsers"
 authors = ["hodakamori"]

--- a/crates/megane-wasm/Cargo.toml
+++ b/crates/megane-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "megane-wasm"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "WASM bindings for megane molecular viewer"
 authors = ["hodakamori"]

--- a/jupyterlab-megane/package-lock.json
+++ b/jupyterlab-megane/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-jupyterlab",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-jupyterlab",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/application": "^4.0.0",
@@ -679,7 +679,7 @@
       }
     },
     "node_modules/@pkgjs/parseargs": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,

--- a/jupyterlab-megane/package.json
+++ b/jupyterlab-megane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-jupyterlab",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "JupyterLab 4 extension for the megane molecular viewer",
   "license": "MIT",
   "author": "hodakamori",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "megane-viewer",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "megane-viewer",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
@@ -508,7 +508,7 @@
       "license": "MIT"
     },
     "node_modules/@dimforge/rapier3d-compat": {
-      "version": "0.13.0",
+      "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "license": "Apache-2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "megane-viewer",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "A fast, beautiful molecular viewer – anywidget-compatible",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "megane"
-version = "0.13.0"
+version = "0.13.1"
 description = "A fast, beautiful molecular viewer"
 requires-python = ">=3.10"
 license = "MIT"
@@ -95,7 +95,7 @@ show_missing = true
 skip_empty = true
 
 [tool.bumpversion]
-current_version = "0.13.0"
+current_version = "0.13.1"
 commit = false
 tag = false
 allow_dirty = true

--- a/python/megane/__init__.py
+++ b/python/megane/__init__.py
@@ -85,4 +85,4 @@ __all__ = [
     "view",
     "view_traj",
 ]
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1756,7 +1756,7 @@ wheels = [
 
 [[package]]
 name = "megane"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/vscode-megane/package-lock.json
+++ b/vscode-megane/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-megane",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-megane",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "devDependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/vscode-megane/package.json
+++ b/vscode-megane/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-megane",
   "displayName": "megane - Molecular Viewer",
   "description": "View molecular structure files (PDB, GRO, XYZ (incl. Jmol .jxyz), MOL, SDF, MOL2, CIF, mmCIF, LAMMPS data, AMBER prmtop, ASE traj, XTC, LAMMPS dump, DCD, AMBER NetCDF, VASP POSCAR/CONTCAR/XDATCAR, CML, Molden, XCrySDen XSF, Chem3D XML, Odyssey xodydata/odydata, CASTEP magres, GAMESS output, CASTEP phonon), volumetric grids (Gaussian CUBE, OpenDX), and JCAMP-DX spectra (.jdx, .jcamp) with megane",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "publisher": "hodakamori",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Release v0.13.1 (patch bump from 0.13.0), prepared with the full `pre-release` checklist against current `main` (afbf5817). The release is bug fixes only, so a patch bump is appropriate. The diff is the version bump across all 11 bump-my-version targets plus `Cargo.lock` / `uv.lock`, and the CHANGELOG cut: `[Unreleased]` renamed to `[0.13.1] - 2026-08-12` with a fresh empty `[Unreleased]` section on top.

Changes shipped in this release (already merged to `main` via #639):
- Fix: four real-world file layouts from Jmol's demo corpus now parse on every host — `.magres` XML-style block delimiters, Chem3D-native `.c3xml`, JCAMP-DX compound (`##BLOCKS=`) and NTUPLES files, and mmCIF content served under the `.cif` extension

## Test Plan

- [x] `npm test` passes (2076 passed, 1 skipped)
- [x] `cargo test -p megane-core` passes (427 passed)
- [x] `python -m pytest` passes (414 passed)
- [x] Manually verified the change in the browser (hero screenshot re-captured and visually verified; live CloudFront demo verified at the asset level — see below)

### Release verification (pre-release skill)

- Version bump verified across all 11 files; no stale `0.13.0` references; `cargo check` synced `Cargo.lock`
- `npm run build` (WASM + app + widget + lib + labextension) green; labextension bundle embeds `0.13.1`
- `maturin build --release` produced the `megane-0.13.1` wheel; `maturin develop` + `jupyter labextension list` shows `megane-jupyterlab v0.13.1 enabled OK`
- `uv run make test-all` green (Python 414, TS 2076, Rust 427, E2E subset 22, notebooks 6, integration 14)
- Full 5-platform Playwright matrix run locally (release requirement, not just the `make test-all` subset):
  - webapp-hosted projects (`webapp`, `contract` via `make test-all`, plus `format-loading`, `playback`, `heterogeneous-traj`, `trajectory-bonds-vdw-leak`, `sidebar`, `licorice`, `water-line`, `pipeline-editor`, `inspector`, `pipeline-file`, `render-modal`, `resname-filter-opacity`, and the 5 Phase-2 `__webapp` variants): **67 passed / 1 one-off flake** — `modify-node__webapp` full-page capture taken before the render settled during the 8-minute batch; the project then passed **4 consecutive isolated runs (12/12 tests)**, so it is not a regression
  - JupyterLab-hosted projects (`widget-jupyterlab`, `jupyterlab-doc` via `make test-all`, plus `widget-api`, `widget-examples`, and Phase-2 `__jupyterlab-doc` / `__widget-jupyterlab` variants): **39 passed / 0 failed**
  - VSCode-hosted projects (`vscode`, `widget-vscode`, Phase-2 `__vscode` / `__widget-vscode` variants) via npm-built code-server with `MEGANE_E2E_MODE=1`: all functional/DOM-contract assertions pass. The only persistent failures are the documented **pixel diffs off the baseline host** (the 9 known `vscode` format tests at 32–39 % plus the Phase-2 `__vscode` full-page baselines at ~37 % and two small drifts: `trajectory-bonds/vscode-bonded` viewer-region 2.86 % and `modify-node/widget-vscode-scale-0_5` 3.45 %) — the `e2e-coverage` skill explicitly says not to re-baseline these from a sandbox, and `.new.png` captures were visually confirmed to render the molecules correctly on both VSCode hosts. One `trajectory-bonds__widget-vscode` functional assertion ("expected zero bonds at frame 4") failed once under batch load and passed 4/4 on an isolated re-run — a timing flake, not a regression (this release touches parsers only)
  - No baselines were re-captured or committed
- CHANGELOG cut to `[0.13.1] - 2026-08-12`; README install/quick-start/format tables verified current (no API or format-support changes in this release)
- `release-dry-run.yml` could not be dispatched from this environment (the `workflow_dispatch` API returns 403 for this integration). Risk is low: the latest dry-run succeeded earlier today (run on `42261da1` during the v0.13.0 release) and none of the publish workflows (`publish-npm.yml`, `publish-pypi.yml`, `publish-vscode.yml`, `release-dry-run.yml`, `docs.yml`) changed since. Please trigger it once from the Actions UI (or `gh workflow run release-dry-run.yml`) before tagging if you want the CI-side confirmation
- Live demo (https://megane.tech-office-mori.com): the deploy workflow run for current `main` (`afbf5817`, run 31587335999) succeeded, and the site serves exactly the asset hashes that run uploaded (index + all bundles HTTP 200). A browser-level screenshot was not possible because this sandbox's egress proxy blocks Chromium's external connections, but the identical `main` build renders correctly in the local webapp E2E and the hero screenshot
- Hero screenshot re-captured and visually verified (not committed — regenerated artifact only)

### After merge

Tag the merge commit on `main` to trigger the publish workflows:

```
git tag v0.13.1
git push origin v0.13.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015uwYqmhA6kxKwv6tEB7vne

---
_Generated by [Claude Code](https://claude.ai/code/session_015uwYqmhA6kxKwv6tEB7vne)_