### PR TITLE
fix: resolve new Rust 1.98 clippy lints in megane-core

### DIFF
--- a/crates/megane-core/src/odydata.rs
+++ b/crates/megane-core/src/odydata.rs
@@ -361,7 +361,7 @@ fn parse_text(text: &str) -> Result<Raw, String> {
                 tokens.extend(line.split_whitespace());
             }
             if tokens.len() > n_atoms {
-                for tri in tokens[n_atoms..].chunks_exact(3) {
+                for tri in tokens[n_atoms..].as_chunks::<3>().0 {
                     let (Ok(a), Ok(b), Ok(order)) = (
                         tri[0].parse::<usize>(),
                         tri[1].parse::<usize>(),

--- a/crates/megane-core/src/xtc.rs
+++ b/crates/megane-core/src/xtc.rs
@@ -271,15 +271,14 @@ fn decompress_coords(xdr: &mut XdrReader, natoms: usize) -> Result<Vec<f32>, Str
 
     // Determine encoding mode
     let mut bitsizeint = [0u32; 3];
-    let bitsize;
-    if (sizeint[0] | sizeint[1] | sizeint[2]) > 0x00ff_ffff {
+    let bitsize = if (sizeint[0] | sizeint[1] | sizeint[2]) > 0x00ff_ffff {
         bitsizeint[0] = sizeofint(sizeint[0]);
         bitsizeint[1] = sizeofint(sizeint[1]);
         bitsizeint[2] = sizeofint(sizeint[2]);
-        bitsize = 0;
+        0
     } else {
-        bitsize = sizeofints(3, &sizeint);
-    }
+        sizeofints(3, &sizeint)
+    };
 
     let mut smallidx = xdr.read_i32()? as usize;
     let tmp_idx = if smallidx > 0 { smallidx - 1 } else { 0 };


### PR DESCRIPTION
## Summary

CI on `main` is red: the **Rust lint & format** job fails because the `dtolnay/rust-toolchain@stable` toolchain moved to Rust 1.98.0, whose clippy introduced two new lints that trip `-D warnings` on existing code (first failing run: [CI #3276](https://github.com/hodakamori/megane/actions/runs/32449785689), also [CI #3277](https://github.com/hodakamori/megane/actions/runs/32449831797)):

- `clippy::chunks_exact_to_as_chunks` at `crates/megane-core/src/odydata.rs:364` — the HESSIAN bond-triple iteration now uses `as_chunks::<3>().0` instead of `chunks_exact(3)`.
- `clippy::needless_late_init` at `crates/megane-core/src/xtc.rs:274` — `bitsize` is now assigned directly from the `if/else` expression instead of late-initialized in each branch.

Both changes are behavior-preserving refactors, applied exactly as clippy suggests; no functional change to either parser.

## Test Plan

- [ ] `npm test` passes (no TS changes)
- [x] `cargo test -p megane-core` passes (427 tests)
- [ ] `python -m pytest` passes (if Python changes are included) — no Python changes
- [x] `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` pass locally
- [x] `cargo llvm-cov --package megane-core` confirms the changed lines are covered (patch coverage 3/4 measurable lines; the one miss is the pre-existing uncovered large-coordinate XTC branch)
- [x] E2E (rule #9, `crates/megane-core` paths feeding the renderer): ran Playwright projects `webapp`, `format-loading` (includes odydata + XTC companion loading), `playback` (XTC decode), `trajectory-bonds__webapp`, `heterogeneous-traj` — all 44 tests pass, no baseline changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjisGsduiZGWXuEP1AdDcy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JjisGsduiZGWXuEP1AdDcy)_