### PR TITLE
docs: contributor-facing policies (fork CI, design rules, CoC, security)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
           components: llvm-tools-preview
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --package megane-core --lcov --output-path lcov.info
+      # Fork PRs: secrets are not passed to fork-triggered runs, so
+      # CODECOV_TOKEN resolves to an empty string there. That is expected
+      # and fine — codecov-action v5 falls back to a tokenless upload for
+      # PRs from forks of public repos, so the patch-coverage gate still
+      # works for external contributors. Do NOT "fix" the empty token by
+      # gating this step on the secret; that would silently skip the gate
+      # for forks. If a tokenless upload fails transiently (rate limit),
+      # re-run the job. The same applies to the test-ts and test-python
+      # upload steps below.
       - uses: codecov/codecov-action@v5
         with:
           files: lcov.info

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,78 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer, [@hodakamori](https://github.com/hodakamori).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,15 @@ UI-affecting changes are covered by a Playwright E2E suite with pixel-diff basel
 
 Codecov measures unit-test coverage only (patch coverage ≥ 70 % is required on every PR); E2E does not count toward it, so new code still needs unit tests.
 
+### CI on fork pull requests
+
+Everything you need runs automatically on PRs from forks — no secrets or special setup required on your side:
+
+- The full CI suite (lint, Rust/TS/Python tests, builds) and the E2E pixel checks run on fork PRs; the E2E jobs compare against the `tests/e2e/baselines-ci/` PNGs committed in the repository.
+- Coverage uploads work without a token: this is a public repository, so codecov-action falls back to a tokenless upload for fork PRs. If the upload step itself fails transiently (e.g. a rate limit), ask a maintainer to re-run the job — do not try to work around the coverage gate.
+- The **"E2E update baselines"** flow (the `update-e2e-baselines` label) cannot push to fork branches, so if your change intentionally shifts pixels, say so in the PR description and a maintainer will re-record `baselines-ci/` for you.
+- The `llm-eval` label is maintainer-only (it triggers paid API calls) and is a no-op for other users.
+
 ## Code Style
 
 - **TypeScript** -- Strict mode enabled. Use the `@/` import alias for paths under `src/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,37 @@ Everything you need runs automatically on PRs from forks — no secrets or speci
 
 Commit messages must be written in English.
 
+## Design Rules
+
+A few project-wide rules come up in almost every review — knowing them up
+front saves a round trip:
+
+- **Parsers read files as-is.** A parser must return exactly what the file
+  asserts — nothing added, dropped, reordered, or restyled. Anything that
+  changes what the user *sees* (symmetry expansion, unwrapping, filtering,
+  supercells, bond rewrites, coloring, …) belongs in a pipeline node, so the
+  user can see and disable it in the editor. The only transformations allowed
+  inside a parser are lossless canonicalizations (unit conversion declared by
+  the file/format, element resolution, bond inference *only* when the format
+  carries no connectivity, identity-preserving reindexing). Known existing
+  violations are catalogued in
+  [`docs/docs/dev/parser-purity-audit.md`](docs/docs/dev/parser-purity-audit.md)
+  — please do not add new ones.
+- **New file formats and pipeline nodes must work on every host.** megane
+  ships as a webapp, Jupyter widget, JupyterLab extension, VSCode extension,
+  and Python API. When you add a format or node, register it on all of them
+  (the walkthroughs in
+  [`docs/docs/dev/architecture.md`](docs/docs/dev/architecture.md) and
+  [`docs/docs/dev/custom-nodes.md`](docs/docs/dev/custom-nodes.md) list every
+  registration point) and update the tables in
+  [`docs/docs/platform-support.md`](docs/docs/platform-support.md) in the same
+  PR. Host drift is the #1 source of "works in the webapp but not in VSCode"
+  bugs.
+- **Performance changes must be measured.** A change justified as "faster"
+  needs a before/after A/B measurement (see `scripts/profile-loading.mjs` and
+  `scripts/profile-streaming.mjs`), and is only merged if the numbers show a
+  win. Include the before/after table in the PR description.
+
 ## Submitting a Pull Request
 
 1. Fork the repository and create a feature branch from `main`.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,15 @@ python/megane/           Python backend
 tests/                   Tests (Python, TypeScript, E2E)
 ```
 
+## Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+development setup, test commands, and project design rules. Fork PRs run the
+full CI and E2E pixel checks automatically — no tokens or setup needed on
+your side. This project follows the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md); security issues
+should be reported privately per [SECURITY.md](SECURITY.md).
+
 ## License
 
 [MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest released version. Please make sure
+you are running the most recent release of the `megane` package (PyPI),
+`megane-viewer` (npm), or the VSCode extension before reporting.
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub
+issues.**
+
+Instead, use GitHub's private vulnerability reporting: go to the
+[Security tab](https://github.com/hodakamori/megane/security) of this
+repository and click **"Report a vulnerability"**. This opens a private
+advisory that only the maintainer can see.
+
+Please include as much of the following as you can:
+
+- The affected component (Python package, webapp, Jupyter widget, JupyterLab
+  extension, VSCode extension, or a specific file parser) and version
+- Steps to reproduce, ideally with a minimal input file if the issue is in a
+  parser
+- The impact you believe the issue has (e.g. arbitrary code execution when
+  opening a crafted structure file)
+
+You should receive an initial response within a week. Once the issue is
+confirmed and fixed, the fix ships in the next release and the advisory is
+published with credit to the reporter (unless you prefer to stay anonymous).
+
+Because megane parses untrusted files (structure and trajectory formats) in
+Rust/WASM and Python, parser crashes on malformed input are welcome as
+regular bug reports — the private channel is for issues with a plausible
+security impact such as memory unsafety, sandbox escape, or code execution.


### PR DESCRIPTION
## Summary

Rounds out the contributor-facing documentation so external contributions can be accepted smoothly. Two commits, docs and workflow comments only — no behavior changes.

**Fork-PR CI behavior (verified + documented):**
- Verified the repository is public and the Codecov uploads use `codecov-action@v5`, which falls back to a **tokenless upload** for PRs from forks of public repos when `secrets.CODECOV_TOKEN` resolves empty. The patch-coverage gate (≥ 70 %) therefore still applies to fork PRs with no configuration change needed.
- `.github/workflows/ci.yml`: comment on the Codecov upload steps explaining the empty-token/tokenless mechanism and warning against "fixing" it by gating the step on the secret (which would silently skip the gate for forks). `fail_ci_on_error: true` stays on everywhere.
- `CONTRIBUTING.md`: new "CI on fork pull requests" section — full CI + E2E pixel checks run on fork PRs with no setup, coverage uploads are tokenless, the `update-e2e-baselines` label cannot push to fork branches (a maintainer re-records), and `llm-eval` is maintainer-only.

**Design rules for contributors:**
- `CONTRIBUTING.md` gains a "Design Rules" section covering the three project-wide rules that come up in every review: parser purity (parsers read files as-is; anything user-visible is pipeline-node work, with a link to `parser-purity-audit.md`), every-host registration for new formats/nodes with the `platform-support.md` update obligation, and mandatory before/after measurement for performance changes.

**Community standards files:**
- `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1. Contact is the maintainer's GitHub profile — no private email is published (commit history uses the noreply address).
- `SECURITY.md`: directs vulnerability reports to GitHub's private vulnerability reporting (Security tab) instead of public issues. Note for the maintainer: enable "Private vulnerability reporting" under Settings → Security so the report button exists.
- `README.md`: new Contributing section linking CONTRIBUTING.md / CODE_OF_CONDUCT.md / SECURITY.md and noting fork PRs run the full CI automatically.

## Test Plan

- [x] `npm test` passes — not run for this PR: docs and workflow comments only, no code changed
- [x] `cargo test -p megane-core` passes — no Rust changes
- [x] `python -m pytest` passes (if Python changes are included) — no Python changes
- [x] Manually verified the change in the browser (if UI changes are included) — no UI changes
- [x] `ci.yml` YAML validated locally; CI + E2E on this PR exercise the unchanged pipelines end-to-end